### PR TITLE
Ignore failed API calls

### DIFF
--- a/custom_components/vdl_parkings/api.py
+++ b/custom_components/vdl_parkings/api.py
@@ -28,4 +28,16 @@ class VdlParkingApi:
 
                 response.raise_for_status()
 
+                # Validate content-type before JSON parsing
+                if "application/json" not in content_type:
+                    _LOGGER.warning(
+                        "Unexpected content-type from API: %s. Response preview: %s",
+                        content_type,
+                        text[:200],
+                    )
+                    raise ValueError(
+                        f"Unexpected content-type: {content_type}. "
+                        "Expected application/json."
+                    )
+
                 return await response.json()

--- a/custom_components/vdl_parkings/coordinator.py
+++ b/custom_components/vdl_parkings/coordinator.py
@@ -28,7 +28,12 @@ class VdlParkingCoordinator(DataUpdateCoordinator):
         )
 
     async def _async_update_data(self):
-        data = await self.api.fetch()
+        try:
+            data = await self.api.fetch()
+        except ValueError as err:
+            # Transient error: log it but allow coordinator to keep last-known-good data
+            _LOGGER.warning("Ignoring failed API call: %s", err)
+            raise
 
         parkings = {}
 


### PR DESCRIPTION
https://github.com/pschmucker/vdl-parkings/issues/21: ignore failed API calls.
This fix simply verifies the content-type and raise an error if it's not application/json.